### PR TITLE
Replacing new Buffer(..) with Buffer.from(..) due to deprecation.

### DIFF
--- a/twister-proxy.js
+++ b/twister-proxy.js
@@ -59,7 +59,7 @@ var invalidRequestCounter = 0;
 var forbiddenCallCounter = 0;
 var connectionErrorMessageDisplayed = false;
 
-var auth = "Basic " + new Buffer(settings.RPC.user + ":" + settings.RPC.password).toString("base64");
+var auth = "Basic " + Buffer.from(settings.RPC.user + ":" + settings.RPC.password).toString("base64");
 
 settings.CallLimits.forEach(function(x) {
     maxCallsPerMinute[x.name] = x.maxPerMinute;


### PR DESCRIPTION
https://github.com/digital-dreamer/twister-proxy/issues/12
https://app.bountysource.com/issues/109490342-buffer-is-deprecated-due-to-security-and-usability-issues