### PR TITLE
new Buffer => Buffer.from (a fix for https://github.com/digital-dreamer/twister-proxy/issues/12)

### DIFF
--- a/twister-proxy.js
+++ b/twister-proxy.js
@@ -59,7 +59,7 @@ var invalidRequestCounter = 0;
 var forbiddenCallCounter = 0;
 var connectionErrorMessageDisplayed = false;
 
-var auth = "Basic " + new Buffer(settings.RPC.user + ":" + settings.RPC.password).toString("base64");
+var auth = "Basic " + Buffer.from(settings.RPC.user + ":" + settings.RPC.password).toString("base64");
 
 settings.CallLimits.forEach(function(x) {
     maxCallsPerMinute[x.name] = x.maxPerMinute;


### PR DESCRIPTION
This fix follows the guide at https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/ , variant 1 (I chose this variant because there's no particular version of node.js mentioned in the project; if I was wrong, I can switch it to variant 2 in minutes).
